### PR TITLE
Overhaul container builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,8 +353,7 @@
         <quarkus.container-image.additional-tags>native</quarkus.container-image.additional-tags>
         <quarkus.docker.build-args.PROVIDER_IMAGE>${quarkus.native.builder-image}</quarkus.docker.build-args.PROVIDER_IMAGE>
         <quarkus.docker.dockerfile-native-path>src/main/container/Containerfile.native-distroless</quarkus.docker.dockerfile-native-path>
-        <!-- Tag: 22.3-java17 -->
-        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image@sha256:adffb204595d48a4258ff379b51f8831cb13fc8ab5b0f3ad5f6e5df20f02c7e7</quarkus.native.builder-image>
+        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17@sha256:88b1d79140d2cc79e1e7808efdd72e930ee7ae07d56a7b9ad5e2152261488ef6</quarkus.native.builder-image>
         <quarkus.native.container-build>true</quarkus.native.container-build>
         <quarkus.package.type>native</quarkus.package.type>
         <skipITs>false</skipITs>

--- a/src/main/container/Containerfile.native-distroless
+++ b/src/main/container/Containerfile.native-distroless
@@ -1,14 +1,15 @@
-ARG PROVIDER_IMAGE
+ARG PROVIDER_IMAGE="quay.io/quarkus/ubi-quarkus-mandrel-builder-image:22.3-java17@sha256:88b1d79140d2cc79e1e7808efdd72e930ee7ae07d56a7b9ad5e2152261488ef6"
+ARG DISTROLESS_IMAGE="quay.io/quarkus/quarkus-distroless-image:2.0@sha256:28d0f7ad578426ea434c09394eef7d46e3b7b106ded9438477224367995e244a"
+
 FROM ${PROVIDER_IMAGE} AS provider
 USER root
 WORKDIR /libs_to_copy
 COPY \
   --chmod=700 \
-  src/main/container/scripts/keep-relevant-libs.sh /bin
-RUN keep-relevant-libs.sh
+  src/main/container/scripts/move-relevant-libs-to-pwd.sh /bin
+RUN move-relevant-libs-to-pwd.sh
 
-# Tag: 2.0
-FROM quay.io/quarkus/quarkus-distroless-image@sha256:6b8bdd0419b4aad072ea93514bbc883213e67a87f827721f84ccf3bd692247a1
+FROM ${DISTROLESS_IMAGE} as runner
 ARG APP_DIR=/deployment
 ARG UID=1001
 

--- a/src/main/container/Containerfile.temurin
+++ b/src/main/container/Containerfile.temurin
@@ -1,5 +1,6 @@
-# Tag: 17.0.6_10-jre-alpine
-FROM docker.io/eclipse-temurin@sha256:c26a727c4883eb73d32351be8bacb3e70f390c2c94f078dc493495ed93c60c2f
+ARG TEMURIN_IMAGE="docker.io/eclipse-temurin:17.0.7_7-jre-alpine@sha256:dd8238c151293ae6a7c22898ef2f0df2af8a05786aef73ccd3248e73765969ed"
+
+FROM ${TEMURIN_IMAGE} as runner
 ARG APP_DIR=/deployment
 ARG UID=1001
 

--- a/src/main/container/scripts/move-relevant-libs-to-pwd.sh
+++ b/src/main/container/scripts/move-relevant-libs-to-pwd.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+function relevant_libs() {
+  local relevant_libs=( \
+    'libbz2' \
+    'libfreetype' \
+    'libpng16' \
+  )
+  echo "${relevant_libs[*]}"
+}
+
+function relevant_libs_regex() {
+  echo ".*($(IFS='|'; echo "$(relevant_libs)"))\.so.*"
+}
+
+
 function copy_lib64_to_pwd() {
   cp \
    --no-dereference \
@@ -17,11 +31,12 @@ function files_in_pwd() {
   echo "${files[*]}"
 }
 
-function files_in_pwd_to_keep() {
+function libs_in_pwd_to_keep() {
   local files_to_keep=()
+  local relevant_libs_regex="$(relevant_libs_regex)"
   for file in "${@}"
   do
-    if [[ "${file}" =~ .*(libfreetype|libbz2|libpng16)\.so.* ]]
+    if [[ "${file}" =~ ${relevant_libs_regex} ]]
     then
       files_to_keep+=( "${file}" )
     fi
@@ -29,21 +44,21 @@ function files_in_pwd_to_keep() {
   echo "${files_to_keep[*]}"
 }
 
-function remove_unwanted_files_from_pwd() {
+function remove_unwanted_libs_from_pwd() {
   local files=()
   mapfile \
     -d ' ' `# set delimiter` \
     -t `# truncate trailing delimiter` \
     files < <(files_in_pwd)
-  local files_to_keep=()
+  local libs_to_keep=()
   mapfile \
     -d ' ' `# set delimiter` \
     -t `# truncate trailing delimiter` \
-    files_to_keep < <(files_in_pwd_to_keep "${files[@]}")
+    libs_to_keep < <(libs_in_pwd_to_keep "${files[@]}")
   for file in "${files[@]}"
   do
     file="${file%%[[:space:]]}"
-    if [[ ! "${files_to_keep[*]}" =~ (^|.*[[:space:]]+)"${file}"([[:space:]]+.*|$).* ]]
+    if [[ ! "${libs_to_keep[*]}" =~ (^|.*[[:space:]]+)"${file}"([[:space:]]+.*|$).* ]]
     then
       rm -rf "${file}"
     fi
@@ -52,7 +67,7 @@ function remove_unwanted_files_from_pwd() {
 
 function run() {
   copy_lib64_to_pwd
-  remove_unwanted_files_from_pwd
+  remove_unwanted_libs_from_pwd
 }
 
 run


### PR DESCRIPTION
- Restructurize keep-relevant-libs.sh
- Rename keep-relevant-libs.sh to move-relevant-libs-to-pwd.sh
- Parameterize Containerfile.native-distroless and Containerfile.temurin
- Name all stages in all containerfiles
- Update to latest tag-versions
- Reference images by tag and digest