### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/de/turing85/qr/code/generator/exceptionmapper/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/de/turing85/qr/code/generator/exceptionmapper/ConstraintViolationExceptionMapper.java
@@ -11,9 +11,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 @Provider
 @SuppressWarnings("unused")
 public class ConstraintViolationExceptionMapper

--- a/src/test/java/de/turing85/qr/code/generator/actor/QrCodeActor.java
+++ b/src/test/java/de/turing85/qr/code/generator/actor/QrCodeActor.java
@@ -18,7 +18,6 @@ import com.google.zxing.client.j2se.BufferedImageLuminanceSource;
 import com.google.zxing.common.HybridBinarizer;
 import de.turing85.qr.code.generator.exceptionmapper.ErrorResponse;
 import io.restassured.response.ValidatableResponse;
-import org.jboss.resteasy.reactive.RestResponse;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
@@ -81,7 +80,7 @@ public class QrCodeActor {
   }
 
   public void responseIsBadRequest() {
-    response.statusCode(RestResponse.Status.BAD_REQUEST.getStatusCode());
+    response.statusCode(Response.Status.BAD_REQUEST.getStatusCode());
     ErrorResponse errorResponse = response.extract().body().as(ErrorResponse.class);
     Truth.assertThat(errorResponse.message()).isNotNull();
     Truth.assertThat(errorResponse.message()).isNotEmpty();


### PR DESCRIPTION
- use jakarta.ws.rs.core.Response instead of org.jboss.resteasy.reactive.RestResponse in QrCodeActor
- Remove unnecessary logger in ConstraintViolationExceptionMapper