### PR TITLE
Download maven state by name instead of pattern

### DIFF
--- a/.github/actions/owasp-scan/action.yml
+++ b/.github/actions/owasp-scan/action.yml
@@ -46,7 +46,7 @@ runs:
       uses: actions/download-artifact@v4
       if: ${{ inputs.download-artifacts == 'true' }}
       with:
-        pattern: maven-state
+        name: maven-state
 
     - name: Download Compiled Classes
       uses: actions/download-artifact@v4

--- a/.github/actions/populate-cache/action.yml
+++ b/.github/actions/populate-cache/action.yml
@@ -30,12 +30,6 @@ runs:
         java-version: ${{ inputs.java-version }}
         version: ${{ inputs.graalvm-version }}
 
-    - name: OWASP DB Cache
-      uses: actions/cache@v4
-      with:
-        path: owasp-db
-        key: owasp-db
-
     - name: Populate Cache
       if: ${{ steps.setup.outputs.cache-hit != 'true' }}
       shell: sh


### PR DESCRIPTION
In the OWASP Scan step, download the maven state by name, not by pattern