### PR TITLE
Image updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <quarkus.docker.dockerfile-native-path>src/main/container/Containerfile.native-distroless</quarkus.docker.dockerfile-native-path>
     <quarkus.docker.dockerfile-jvm-path>src/main/container/Containerfile.temurin</quarkus.docker.dockerfile-jvm-path>
     <quarkus-maven-plugin.skip>false</quarkus-maven-plugin.skip>
-    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1.3.1-Final-java21-2024-05-10@sha256:c3d940fbb143206ed868bffb7ad68b9fef0e704ecfeee2459fea71e003383f92</quarkus.native.builder-image>
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1.3.1-Final-java21-2024-07-14@sha256:5f4e96cc1b7b085ab196afadb6f36cb9f0a9e6ebbc02a15be3a4260b22e5f6f6</quarkus.native.builder-image>
     <quarkus.native.container-build>true</quarkus.native.container-build>
     <skipITs>false</skipITs>
   </properties>

--- a/src/main/container/Containerfile.native-distroless
+++ b/src/main/container/Containerfile.native-distroless
@@ -1,4 +1,4 @@
-ARG DISTROLESS_IMAGE="quay.io/quarkus/quarkus-distroless-image:2.0-2024-05-10@sha256:ae6915675929f863f7fa002de2ce5893742e2d69f8084bb5effbb475541fa7e1
+ARG DISTROLESS_IMAGE="quay.io/quarkus/quarkus-distroless-image:2.0-2024-07-07@sha256:3e03e8cc07a8e631e2b14b1b013a6b640e92c454acc1e44f1792743ba51af694"
 
 FROM ${DISTROLESS_IMAGE} as runner
 ARG APP_DIR=/deployment

--- a/src/main/container/Containerfile.native-distroless-compressed
+++ b/src/main/container/Containerfile.native-distroless-compressed
@@ -1,11 +1,11 @@
-ARG COMPRESSOR_IMAGE="docker.io/alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b"
-ARG DISTROLESS_IMAGE="quay.io/quarkus/quarkus-distroless-image:2.0@sha256:3b73eb32233f68cc10facb3deec858db3db230830c3a75a78dbb9100ba394a76"
+ARG COMPRESSOR_IMAGE="docker.io/alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0"
+ARG DISTROLESS_IMAGE="quay.io/quarkus/quarkus-distroless-image:2.0-2024-07-07@sha256:3e03e8cc07a8e631e2b14b1b013a6b640e92c454acc1e44f1792743ba51af694"
 
 FROM ${COMPRESSOR_IMAGE} AS compressor
 ARG UPX_INSTALLATION_COMMAND="apk add \
-    libgcc=13.2.1_git20231014-r0 \
-    libstdc++=13.2.1_git20231014-r0 \
-    upx=4.2.1-r0 \
+    libgcc=13.2.1_git20240309-r0 \
+    libstdc++=13.2.1_git20240309-r0 \
+    upx=4.2.4-r0 \
   && rm -rf /var/cache/apt/*"
 ARG UPX_COMPRESSION_MODE="--fast"
 
@@ -28,7 +28,7 @@ USER root
 WORKDIR ${APP_DIR}
 COPY \
   --chmod=444 \
-  /target/*.so /lib/
+  target/*.so /lib/
 COPY \
   --from=compressor \
   --chmod=555 \

--- a/src/main/container/Containerfile.temurin
+++ b/src/main/container/Containerfile.temurin
@@ -1,4 +1,4 @@
-ARG TEMURIN_IMAGE="docker.io/eclipse-temurin:21.0.3_9-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67"
+ARG TEMURIN_IMAGE="docker.io/eclipse-temurin:21.0.3_9-jre-alpine@sha256:f05c742dd20051b104b939370f7db4d6eb420cc7fd842aeb4e2446837da3bd03"
 
 FROM ${TEMURIN_IMAGE} as runner
 ARG APP_DIR=/deployment


### PR DESCRIPTION
Image updates:
- quay.io/quarkus/ubi-quarkus-mandrel-builder-image from 23.1.3.1-Final-java21-2024-06-23@sha256:4a23ad99e08c765e12d48b96235f805066cb7867d3ee7cfc8986f6f9c62e522a to 23.1.3.1-Final-java21-2024-07-14@sha256:5f4e96cc1b7b085ab196afadb6f36cb9f0a9e6ebbc02a15be3a4260b22e5f6f6
- quay.io/quarkus/quarkus-distroless-image from 2.0-2024-05-12@sha256:23457e667e77be43dc27687073af564f7d40178501954cc05bd59a4bf46512e3 to 2.0-2024-07-07@sha256:3e03e8cc07a8e631e2b14b1b013a6b640e92c454acc1e44f1792743ba51af694
- docker.io/alpine from 3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd to 3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
- docker.io/eclipse-temurin from 21.0.3_9-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67 to 21.0.3_9-jre-alpine@sha256:f05c742dd20051b104b939370f7db4d6eb420cc7fd842aeb4e2446837da3bd03